### PR TITLE
Convert NaN to None in TimeSeries Models

### DIFF
--- a/openenergyid/__init__.py
+++ b/openenergyid/__init__.py
@@ -1,6 +1,6 @@
 """Open Energy ID Python SDK."""
 
-__version__ = "0.1.14"
+__version__ = "0.1.15"
 
 from .enums import Granularity
 from .models import TimeDataFrame, TimeSeries


### PR DESCRIPTION
Fixed a bug where Pydantic's JSON dumping would fail when a data array contained NaN values. (Apparently NaN is not JSON compatible, officially).

Converters were added that convert NaN to None when the Pydantic Timeseries models are created.