### PR TITLE
PVGIS Timeouts & Caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,5 @@ temp_notebooks/
 *.pkl
 vis/
 data_gitignore/
+
+.codex

--- a/openenergyid/pvsim/pvlib/main.py
+++ b/openenergyid/pvsim/pvlib/main.py
@@ -54,7 +54,7 @@ class PVLibSimulator(PVSimulator):
         end: dt.date,
         modelchain: pvlib.modelchain.ModelChain,
         weather: pd.DataFrame | None = None,
-        timeout: int = 30,
+        timeout: int = 60,
         retry_count: int = 2,
         retry_backoff_seconds: float = 1.0,
         **kwargs,

--- a/openenergyid/pvsim/pvlib/main.py
+++ b/openenergyid/pvsim/pvlib/main.py
@@ -33,7 +33,7 @@ class PVLibSimulationInput(PVSimulationInputAbstract):
     """
 
     type: Literal["pvlibsimulation"] = Field("pvlibsimulation", frozen=True)  # tag
-    timeout: int = Field(30, gt=0, description="PVGIS request timeout in seconds per attempt")
+    timeout: int = Field(60, gt=0, description="PVGIS request timeout in seconds per attempt")
     retry_count: int = Field(
         2, ge=0, description="Number of PVGIS retries after the initial transient failure"
     )

--- a/openenergyid/pvsim/pvlib/main.py
+++ b/openenergyid/pvsim/pvlib/main.py
@@ -33,6 +33,13 @@ class PVLibSimulationInput(PVSimulationInputAbstract):
     """
 
     type: Literal["pvlibsimulation"] = Field("pvlibsimulation", frozen=True)  # tag
+    timeout: int = Field(30, gt=0, description="PVGIS request timeout in seconds per attempt")
+    retry_count: int = Field(
+        2, ge=0, description="Number of PVGIS retries after the initial transient failure"
+    )
+    retry_backoff_seconds: float = Field(
+        1.0, ge=0, description="Base delay in seconds for exponential retry backoff"
+    )
     modelchain: ModelChainUnion
 
 
@@ -47,6 +54,9 @@ class PVLibSimulator(PVSimulator):
         end: dt.date,
         modelchain: pvlib.modelchain.ModelChain,
         weather: pd.DataFrame | None = None,
+        timeout: int = 30,
+        retry_count: int = 2,
+        retry_backoff_seconds: float = 1.0,
         **kwargs,
     ):
         """
@@ -62,6 +72,9 @@ class PVLibSimulator(PVSimulator):
         self.end = end
         self.modelchain = modelchain
         self.weather = weather
+        self.timeout = timeout
+        self.retry_count = retry_count
+        self.retry_backoff_seconds = retry_backoff_seconds
 
     def simulate(self, **kwargs) -> pd.Series:
         """
@@ -105,11 +118,14 @@ class PVLibSimulator(PVSimulator):
         return cls(modelchain=mc, **input_.model_dump(exclude={"modelchain"}))
 
     async def load_resources(self, session: ClientSession | None = None) -> None:
-        weather = get_weather(
+        weather = await get_weather(
             latitude=self.modelchain.location.latitude,
             longitude=self.modelchain.location.longitude,
             start=self.start,
             end=self.end,
             tz=self.modelchain.location.tz,
+            timeout=self.timeout,
+            retry_count=self.retry_count,
+            retry_backoff_seconds=self.retry_backoff_seconds,
         )
         self.weather = weather

--- a/openenergyid/pvsim/pvlib/weather.py
+++ b/openenergyid/pvsim/pvlib/weather.py
@@ -7,11 +7,96 @@ including timezone-aware handling and leap year adjustments.
 
 import asyncio
 import datetime as dt
+import threading
+import time
 import typing
+from collections import OrderedDict
+from dataclasses import dataclass
 
 import pandas as pd
 import pvlib
 import requests
+
+WeatherCacheKey = tuple[float, float, str]
+_WEATHER_CACHE_MAX_SIZE = 256
+
+
+@dataclass
+class _InFlightWeatherRequest:
+    condition: threading.Condition
+    ready: bool = False
+    value: pd.DataFrame | None = None
+    error: Exception | None = None
+
+
+class _NormalYearWeatherCache:
+    """Thread-safe LRU cache with single-flight loading per weather key."""
+
+    def __init__(self, max_size: int = _WEATHER_CACHE_MAX_SIZE) -> None:
+        self._max_size = max_size
+        self._cache: OrderedDict[WeatherCacheKey, pd.DataFrame] = OrderedDict()
+        self._in_flight: dict[WeatherCacheKey, _InFlightWeatherRequest] = {}
+        self._lock = threading.Lock()
+
+    def clear(self) -> None:
+        """Remove all completed cache entries."""
+        with self._lock:
+            self._cache.clear()
+
+    def get_or_load(
+        self, key: WeatherCacheKey, loader: typing.Callable[[], pd.DataFrame]
+    ) -> pd.DataFrame:
+        creator = False
+
+        with self._lock:
+            cached = self._cache.get(key)
+            if cached is not None:
+                self._cache.move_to_end(key)
+                return cached
+
+            entry = self._in_flight.get(key)
+            if entry is None:
+                entry = _InFlightWeatherRequest(condition=threading.Condition(self._lock))
+                self._in_flight[key] = entry
+                creator = True
+            else:
+                while not entry.ready:
+                    entry.condition.wait()
+
+                if entry.error is not None:
+                    raise entry.error
+                if entry.value is None:
+                    raise RuntimeError("Weather cache load completed without a value.")
+                return entry.value
+
+        if not creator:
+            raise RuntimeError("Unreachable cache loading state.")
+
+        try:
+            value = loader()
+        except Exception as exc:
+            with self._lock:
+                entry.error = exc
+                entry.ready = True
+                self._in_flight.pop(key, None)
+                entry.condition.notify_all()
+            raise
+
+        with self._lock:
+            self._cache[key] = value
+            self._cache.move_to_end(key)
+            while len(self._cache) > self._max_size:
+                self._cache.popitem(last=False)
+
+            entry.value = value
+            entry.ready = True
+            self._in_flight.pop(key, None)
+            entry.condition.notify_all()
+
+        return value
+
+
+_NORMAL_YEAR_WEATHER_CACHE = _NormalYearWeatherCache()
 
 
 def get_utc_offset_on_1_jan(timezone: str) -> int:
@@ -34,11 +119,14 @@ def get_utc_offset_on_1_jan(timezone: str) -> int:
     return int(utc_offset.total_seconds() / 3600)
 
 
-def _get_weather_sync(
+def clear_weather_cache() -> None:
+    """Clear the process-local PVGIS normal-year weather cache."""
+    _NORMAL_YEAR_WEATHER_CACHE.clear()
+
+
+def _download_normal_year_weather_sync(
     latitude: float,
     longitude: float,
-    start: dt.date,
-    end: dt.date,
     tz: str,
     timeout: int,
 ) -> pd.DataFrame:
@@ -51,13 +139,11 @@ def _get_weather_sync(
     Args:
         latitude: Latitude of the location.
         longitude: Longitude of the location.
-        start: Start date (inclusive).
-        end: End date (exclusive).
         tz: Timezone string.
         timeout: PVGIS request timeout in seconds.
 
     Returns:
-        A pandas DataFrame indexed by timestamp with weather data.
+        A pandas DataFrame indexed by timestamp with normal-year weather data.
     """
     # Get a "normal year" from pvgis, it will be indexed in 1990
     utc_offset = get_utc_offset_on_1_jan(tz)
@@ -70,6 +156,25 @@ def _get_weather_sync(
     weather = typing.cast(pd.DataFrame, weather)
     weather = weather.tz_convert(tz)
     weather.index.name = None
+    return weather
+
+
+def _materialize_weather_for_range_sync(
+    normal_year_weather: pd.DataFrame, start: dt.date, end: dt.date, tz: str
+) -> pd.DataFrame:
+    """
+    Align cached normal-year weather to the requested date range.
+
+    Args:
+        normal_year_weather: Cached normal-year weather for the site.
+        start: Start date (inclusive).
+        end: End date (exclusive).
+        tz: Timezone string.
+
+    Returns:
+        A pandas DataFrame indexed by timestamp with weather data.
+    """
+    weather = normal_year_weather.copy()
 
     # Check if 29 februari is included in the weather data
     weather_index = typing.cast(pd.DatetimeIndex, weather.index)
@@ -102,6 +207,85 @@ def _get_weather_sync(
     return df
 
 
+def _load_normal_year_weather_with_retry_sync(
+    latitude: float,
+    longitude: float,
+    tz: str,
+    timeout: int,
+    retry_count: int,
+    retry_backoff_seconds: float,
+) -> pd.DataFrame:
+    """Download normal-year weather with retry logic for transient failures."""
+    transient_exceptions = (requests.Timeout, requests.ConnectionError)
+
+    for attempt in range(retry_count + 1):
+        try:
+            return _download_normal_year_weather_sync(
+                latitude=latitude,
+                longitude=longitude,
+                tz=tz,
+                timeout=timeout,
+            )
+        except transient_exceptions:
+            if attempt == retry_count:
+                raise
+
+            delay = retry_backoff_seconds * (2**attempt)
+            time.sleep(delay)
+
+    raise RuntimeError("Unreachable retry loop state")
+
+
+def _get_cached_normal_year_weather_sync(
+    latitude: float,
+    longitude: float,
+    tz: str,
+    timeout: int,
+    retry_count: int,
+    retry_backoff_seconds: float,
+) -> pd.DataFrame:
+    """Load normal-year weather from the shared cache or fetch on cache miss."""
+    key: WeatherCacheKey = (latitude, longitude, tz)
+    return _NORMAL_YEAR_WEATHER_CACHE.get_or_load(
+        key,
+        lambda: _load_normal_year_weather_with_retry_sync(
+            latitude=latitude,
+            longitude=longitude,
+            tz=tz,
+            timeout=timeout,
+            retry_count=retry_count,
+            retry_backoff_seconds=retry_backoff_seconds,
+        ),
+    )
+
+
+def _get_weather_sync(
+    latitude: float,
+    longitude: float,
+    start: dt.date,
+    end: dt.date,
+    tz: str,
+    timeout: int,
+    retry_count: int,
+    retry_backoff_seconds: float,
+) -> pd.DataFrame:
+    """Load request-specific weather using cached normal-year weather when available."""
+    normal_year_weather = _get_cached_normal_year_weather_sync(
+        latitude=latitude,
+        longitude=longitude,
+        tz=tz,
+        timeout=timeout,
+        retry_count=retry_count,
+        retry_backoff_seconds=retry_backoff_seconds,
+    )
+    return _materialize_weather_for_range_sync(
+        normal_year_weather=normal_year_weather,
+        start=start,
+        end=end,
+        tz=tz,
+    )
+
+
 async def get_weather(
     latitude: float,
     longitude: float,
@@ -113,7 +297,7 @@ async def get_weather(
     retry_backoff_seconds: float = 1.0,
 ) -> pd.DataFrame:
     """
-    Retrieve weather data asynchronously with retry logic for transient failures.
+    Retrieve weather data asynchronously using shared cached normal-year weather.
 
     Args:
         latitude: Latitude of the location.
@@ -128,24 +312,14 @@ async def get_weather(
     Returns:
         A pandas DataFrame indexed by timestamp with weather data.
     """
-    transient_exceptions = (requests.Timeout, requests.ConnectionError)
-
-    for attempt in range(retry_count + 1):
-        try:
-            return await asyncio.to_thread(
-                _get_weather_sync,
-                latitude,
-                longitude,
-                start,
-                end,
-                tz,
-                timeout,
-            )
-        except transient_exceptions:
-            if attempt == retry_count:
-                raise
-
-            delay = retry_backoff_seconds * (2**attempt)
-            await asyncio.sleep(delay)
-
-    raise RuntimeError("Unreachable retry loop state")
+    return await asyncio.to_thread(
+        _get_weather_sync,
+        latitude,
+        longitude,
+        start,
+        end,
+        tz,
+        timeout,
+        retry_count,
+        retry_backoff_seconds,
+    )

--- a/openenergyid/pvsim/pvlib/weather.py
+++ b/openenergyid/pvsim/pvlib/weather.py
@@ -5,11 +5,13 @@ Provides functions to retrieve and process weather data for PV simulations,
 including timezone-aware handling and leap year adjustments.
 """
 
+import asyncio
 import datetime as dt
 import typing
 
 import pandas as pd
 import pvlib
+import requests
 
 
 def get_utc_offset_on_1_jan(timezone: str) -> int:
@@ -32,8 +34,13 @@ def get_utc_offset_on_1_jan(timezone: str) -> int:
     return int(utc_offset.total_seconds() / 3600)
 
 
-def get_weather(
-    latitude: float, longitude: float, start: dt.date, end: dt.date, tz: str
+def _get_weather_sync(
+    latitude: float,
+    longitude: float,
+    start: dt.date,
+    end: dt.date,
+    tz: str,
+    timeout: int,
 ) -> pd.DataFrame:
     """
     Retrieve and process weather data for the specified location and date range.
@@ -47,6 +54,7 @@ def get_weather(
         start: Start date (inclusive).
         end: End date (exclusive).
         tz: Timezone string.
+        timeout: PVGIS request timeout in seconds.
 
     Returns:
         A pandas DataFrame indexed by timestamp with weather data.
@@ -54,7 +62,10 @@ def get_weather(
     # Get a "normal year" from pvgis, it will be indexed in 1990
     utc_offset = get_utc_offset_on_1_jan(tz)
     weather = pvlib.iotools.get_pvgis_tmy(
-        latitude=latitude, longitude=longitude, roll_utc_offset=utc_offset
+        latitude=latitude,
+        longitude=longitude,
+        timeout=timeout,
+        roll_utc_offset=utc_offset,
     )[0]
     weather = typing.cast(pd.DataFrame, weather)
     weather = weather.tz_convert(tz)
@@ -89,3 +100,52 @@ def get_weather(
     df = df.iloc[:-1]
 
     return df
+
+
+async def get_weather(
+    latitude: float,
+    longitude: float,
+    start: dt.date,
+    end: dt.date,
+    tz: str,
+    timeout: int = 30,
+    retry_count: int = 2,
+    retry_backoff_seconds: float = 1.0,
+) -> pd.DataFrame:
+    """
+    Retrieve weather data asynchronously with retry logic for transient failures.
+
+    Args:
+        latitude: Latitude of the location.
+        longitude: Longitude of the location.
+        start: Start date (inclusive).
+        end: End date (exclusive).
+        tz: Timezone string.
+        timeout: PVGIS request timeout in seconds per attempt.
+        retry_count: Number of retries after the initial failed attempt.
+        retry_backoff_seconds: Base delay in seconds for exponential retry backoff.
+
+    Returns:
+        A pandas DataFrame indexed by timestamp with weather data.
+    """
+    transient_exceptions = (requests.Timeout, requests.ConnectionError)
+
+    for attempt in range(retry_count + 1):
+        try:
+            return await asyncio.to_thread(
+                _get_weather_sync,
+                latitude,
+                longitude,
+                start,
+                end,
+                tz,
+                timeout,
+            )
+        except transient_exceptions:
+            if attempt == retry_count:
+                raise
+
+            delay = retry_backoff_seconds * (2**attempt)
+            await asyncio.sleep(delay)
+
+    raise RuntimeError("Unreachable retry loop state")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "pandera[polars]>=0.22.1",
     "pvlib>=0.13.0",
     "pydantic>=2.8.2",
+    "requests>=2.32.3",
     "scikit-learn>=1.8.0",
     "statsmodels>=0.14.2",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -377,6 +377,7 @@ requests==2.32.3
     #   energyid
     #   entsoe-py
     #   jupyterlab-server
+    #   openenergyid
     #   pvlib
 requirements-parser==0.13.0
     # via deptry

--- a/requirements.txt
+++ b/requirements.txt
@@ -74,7 +74,9 @@ pytz==2025.2
     #   pandas
     #   pvlib
 requests==2.32.3
-    # via pvlib
+    # via
+    #   openenergyid
+    #   pvlib
 scikit-learn==1.8.0
     # via openenergyid
 scipy==1.15.3

--- a/tests/pvsim/test_pvlib_weather.py
+++ b/tests/pvsim/test_pvlib_weather.py
@@ -1,0 +1,299 @@
+import asyncio
+import datetime as dt
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+import requests
+
+from openenergyid.pvsim.pvlib import main as pvlib_main_module
+from openenergyid.pvsim.pvlib import weather as weather_module
+from openenergyid.pvsim.pvlib.main import PVLibSimulationInput, PVLibSimulator
+
+
+def _make_pvlib_input(**overrides) -> PVLibSimulationInput:
+    payload = {
+        "type": "pvlibsimulation",
+        "start": "2024-01-01",
+        "end": "2024-01-02",
+        "timeout": 12,
+        "retry_count": 3,
+        "retry_backoff_seconds": 0.5,
+        "modelchain": {
+            "type": "quickscan",
+            "system": {
+                "surface_tilt": 35,
+                "surface_azimuth": 180,
+                "p_inverter": 2000,
+                "modules_per_string": 6,
+                "strings_per_inverter": 1,
+            },
+            "location": {
+                "latitude": 51.2,
+                "longitude": 4.4,
+                "tz": "UTC",
+            },
+        },
+    }
+    payload.update(overrides)
+    return PVLibSimulationInput.model_validate(payload)
+
+
+def _make_weather_frame() -> pd.DataFrame:
+    index = pd.date_range("1990-01-01", periods=25, freq="1h", tz="UTC")
+    return pd.DataFrame(
+        {
+            "temp_air": pd.Series(range(25), index=index, dtype=float),
+            "ghi": pd.Series(range(100, 125), index=index, dtype=float),
+        },
+        index=index,
+    )
+
+
+def _make_dummy_modelchain(tz: str = "UTC") -> SimpleNamespace:
+    location = SimpleNamespace(latitude=51.2, longitude=4.4, tz=tz)
+    return SimpleNamespace(location=location)
+
+
+def test_pvlib_input_accepts_and_serializes_request_controls() -> None:
+    input_model = _make_pvlib_input()
+    dumped = input_model.model_dump()
+    schema = PVLibSimulationInput.model_json_schema()
+
+    assert input_model.timeout == 12
+    assert input_model.retry_count == 3
+    assert input_model.retry_backoff_seconds == pytest.approx(0.5)
+    assert dumped["timeout"] == 12
+    assert dumped["retry_count"] == 3
+    assert dumped["retry_backoff_seconds"] == pytest.approx(0.5)
+    assert "timeout" in schema["properties"]
+    assert "retry_count" in schema["properties"]
+    assert "retry_backoff_seconds" in schema["properties"]
+
+
+def test_from_pydantic_stores_timeout_and_retry_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    input_model = _make_pvlib_input()
+    dummy_modelchain = _make_dummy_modelchain()
+
+    monkeypatch.setattr(pvlib_main_module, "to_pv", lambda _: dummy_modelchain)
+
+    simulator = PVLibSimulator.from_pydantic(input_model)
+
+    assert simulator.modelchain is dummy_modelchain
+    assert simulator.timeout == 12
+    assert simulator.retry_count == 3
+    assert simulator.retry_backoff_seconds == pytest.approx(0.5)
+
+
+def test_load_resources_awaits_weather_loader_and_stores_weather(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected = pd.DataFrame({"ghi": [1.0]}, index=pd.date_range("2024-01-01", periods=1, tz="UTC"))
+    simulator = PVLibSimulator(
+        start=dt.date(2024, 1, 1),
+        end=dt.date(2024, 1, 2),
+        modelchain=_make_dummy_modelchain(),
+        timeout=9,
+        retry_count=4,
+        retry_backoff_seconds=0.25,
+    )
+    calls: list[dict[str, object]] = []
+
+    async def fake_get_weather(**kwargs):
+        calls.append(kwargs)
+        return expected
+
+    monkeypatch.setattr(pvlib_main_module, "get_weather", fake_get_weather)
+
+    asyncio.run(simulator.load_resources())
+
+    assert simulator.weather is expected
+    assert calls == [
+        {
+            "latitude": 51.2,
+            "longitude": 4.4,
+            "start": dt.date(2024, 1, 1),
+            "end": dt.date(2024, 1, 2),
+            "tz": "UTC",
+            "timeout": 9,
+            "retry_count": 4,
+            "retry_backoff_seconds": 0.25,
+        }
+    ]
+
+
+def test_get_weather_uses_to_thread(monkeypatch: pytest.MonkeyPatch) -> None:
+    expected = pd.DataFrame({"ghi": [1.0]}, index=pd.date_range("2024-01-01", periods=1, tz="UTC"))
+    to_thread_calls: list[tuple[object, tuple[object, ...]]] = []
+
+    def fake_get_weather_sync(*args, **kwargs):
+        raise AssertionError("sync helper should be invoked through asyncio.to_thread")
+
+    async def fake_to_thread(func, *args):
+        to_thread_calls.append((func, args))
+        return expected
+
+    monkeypatch.setattr(weather_module, "_get_weather_sync", fake_get_weather_sync)
+    monkeypatch.setattr(weather_module.asyncio, "to_thread", fake_to_thread)
+
+    result = asyncio.run(
+        weather_module.get_weather(
+            latitude=51.2,
+            longitude=4.4,
+            start=dt.date(2024, 1, 1),
+            end=dt.date(2024, 1, 2),
+            tz="UTC",
+            timeout=7,
+        )
+    )
+
+    assert result is expected
+    assert to_thread_calls == [
+        (
+            fake_get_weather_sync,
+            (51.2, 4.4, dt.date(2024, 1, 1), dt.date(2024, 1, 2), "UTC", 7),
+        )
+    ]
+
+
+def test_get_weather_sync_forwards_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, object]] = []
+    weather_frame = _make_weather_frame()
+
+    def fake_get_pvgis_tmy(**kwargs):
+        calls.append(kwargs)
+        return weather_frame.copy(), {"meta": "ignored"}
+
+    monkeypatch.setattr(weather_module.pvlib.iotools, "get_pvgis_tmy", fake_get_pvgis_tmy)
+
+    result = weather_module._get_weather_sync(
+        latitude=51.2,
+        longitude=4.4,
+        start=dt.date(2024, 1, 1),
+        end=dt.date(2024, 1, 2),
+        tz="UTC",
+        timeout=17,
+    )
+
+    assert len(result) == 96
+    assert calls == [
+        {
+            "latitude": 51.2,
+            "longitude": 4.4,
+            "timeout": 17,
+            "roll_utc_offset": 0,
+        }
+    ]
+
+
+def test_get_weather_retries_transient_failures_until_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = {"count": 0}
+    sleep_calls: list[float] = []
+    expected = pd.DataFrame({"ghi": [1.0]}, index=pd.date_range("2024-01-01", periods=1, tz="UTC"))
+
+    def fake_get_weather_sync(*args, **kwargs):
+        attempts["count"] += 1
+        if attempts["count"] < 3:
+            raise requests.Timeout("temporary timeout")
+        return expected
+
+    async def fake_to_thread(func, *args):
+        return func(*args)
+
+    async def fake_sleep(delay: float):
+        sleep_calls.append(delay)
+
+    monkeypatch.setattr(weather_module, "_get_weather_sync", fake_get_weather_sync)
+    monkeypatch.setattr(weather_module.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(weather_module.asyncio, "sleep", fake_sleep)
+
+    result = asyncio.run(
+        weather_module.get_weather(
+            latitude=51.2,
+            longitude=4.4,
+            start=dt.date(2024, 1, 1),
+            end=dt.date(2024, 1, 2),
+            tz="UTC",
+            timeout=7,
+            retry_count=2,
+            retry_backoff_seconds=0.5,
+        )
+    )
+
+    assert result is expected
+    assert attempts["count"] == 3
+    assert sleep_calls == [0.5, 1.0]
+
+
+def test_get_weather_raises_after_retry_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    attempts = {"count": 0}
+    sleep_calls: list[float] = []
+
+    def fake_get_weather_sync(*args, **kwargs):
+        attempts["count"] += 1
+        raise requests.ConnectionError("network down")
+
+    async def fake_to_thread(func, *args):
+        return func(*args)
+
+    async def fake_sleep(delay: float):
+        sleep_calls.append(delay)
+
+    monkeypatch.setattr(weather_module, "_get_weather_sync", fake_get_weather_sync)
+    monkeypatch.setattr(weather_module.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(weather_module.asyncio, "sleep", fake_sleep)
+
+    with pytest.raises(requests.ConnectionError, match="network down"):
+        asyncio.run(
+            weather_module.get_weather(
+                latitude=51.2,
+                longitude=4.4,
+                start=dt.date(2024, 1, 1),
+                end=dt.date(2024, 1, 2),
+                tz="UTC",
+                retry_count=2,
+                retry_backoff_seconds=0.25,
+            )
+        )
+
+    assert attempts["count"] == 3
+    assert sleep_calls == [0.25, 0.5]
+
+
+def test_get_weather_does_not_retry_non_retryable_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = {"count": 0}
+    sleep_calls: list[float] = []
+
+    def fake_get_weather_sync(*args, **kwargs):
+        attempts["count"] += 1
+        raise requests.HTTPError("bad request")
+
+    async def fake_to_thread(func, *args):
+        return func(*args)
+
+    async def fake_sleep(delay: float):
+        sleep_calls.append(delay)
+
+    monkeypatch.setattr(weather_module, "_get_weather_sync", fake_get_weather_sync)
+    monkeypatch.setattr(weather_module.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(weather_module.asyncio, "sleep", fake_sleep)
+
+    with pytest.raises(requests.HTTPError, match="bad request"):
+        asyncio.run(
+            weather_module.get_weather(
+                latitude=51.2,
+                longitude=4.4,
+                start=dt.date(2024, 1, 1),
+                end=dt.date(2024, 1, 2),
+                tz="UTC",
+                retry_count=2,
+                retry_backoff_seconds=0.25,
+            )
+        )
+
+    assert attempts["count"] == 1
+    assert sleep_calls == []

--- a/tests/pvsim/test_pvlib_weather.py
+++ b/tests/pvsim/test_pvlib_weather.py
@@ -1,5 +1,8 @@
 import asyncio
 import datetime as dt
+import threading
+import time
+import typing
 from types import SimpleNamespace
 
 import pandas as pd
@@ -48,6 +51,17 @@ def _make_weather_frame() -> pd.DataFrame:
         },
         index=index,
     )
+
+
+async def _awaitable(value):
+    return value
+
+
+@pytest.fixture(autouse=True)
+def clear_weather_cache() -> typing.Iterator[None]:
+    weather_module.clear_weather_cache()
+    yield
+    weather_module.clear_weather_cache()
 
 
 def _make_dummy_modelchain(tz: str = "UTC") -> SimpleNamespace:
@@ -151,12 +165,14 @@ def test_get_weather_uses_to_thread(monkeypatch: pytest.MonkeyPatch) -> None:
     assert to_thread_calls == [
         (
             fake_get_weather_sync,
-            (51.2, 4.4, dt.date(2024, 1, 1), dt.date(2024, 1, 2), "UTC", 7),
+            (51.2, 4.4, dt.date(2024, 1, 1), dt.date(2024, 1, 2), "UTC", 7, 2, 1.0),
         )
     ]
 
 
-def test_get_weather_sync_forwards_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_download_normal_year_weather_sync_forwards_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     calls: list[dict[str, object]] = []
     weather_frame = _make_weather_frame()
 
@@ -166,16 +182,14 @@ def test_get_weather_sync_forwards_timeout(monkeypatch: pytest.MonkeyPatch) -> N
 
     monkeypatch.setattr(weather_module.pvlib.iotools, "get_pvgis_tmy", fake_get_pvgis_tmy)
 
-    result = weather_module._get_weather_sync(
+    result = weather_module._download_normal_year_weather_sync(
         latitude=51.2,
         longitude=4.4,
-        start=dt.date(2024, 1, 1),
-        end=dt.date(2024, 1, 2),
         tz="UTC",
         timeout=17,
     )
 
-    assert len(result) == 96
+    assert result.equals(weather_frame)
     assert calls == [
         {
             "latitude": 51.2,
@@ -186,80 +200,252 @@ def test_get_weather_sync_forwards_timeout(monkeypatch: pytest.MonkeyPatch) -> N
     ]
 
 
-def test_get_weather_retries_transient_failures_until_success(
+def test_same_site_reuses_cached_normal_year_across_simulator_instances(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = {"count": 0}
+    normal_year_weather = _make_weather_frame()
+
+    def fake_download_normal_year_weather_sync(*args, **kwargs):
+        attempts["count"] += 1
+        return normal_year_weather
+
+    monkeypatch.setattr(
+        weather_module,
+        "_download_normal_year_weather_sync",
+        fake_download_normal_year_weather_sync,
+    )
+    monkeypatch.setattr(
+        weather_module.asyncio, "to_thread", lambda func, *args: _awaitable(func(*args))
+    )
+
+    simulator_one = PVLibSimulator(
+        start=dt.date(2024, 1, 1),
+        end=dt.date(2024, 1, 2),
+        modelchain=_make_dummy_modelchain(),
+    )
+    simulator_two = PVLibSimulator(
+        start=dt.date(2024, 1, 1),
+        end=dt.date(2024, 1, 2),
+        modelchain=_make_dummy_modelchain(),
+    )
+
+    asyncio.run(simulator_one.load_resources())
+    asyncio.run(simulator_two.load_resources())
+
+    assert attempts["count"] == 1
+    assert simulator_one.weather is not None
+    assert simulator_two.weather is not None
+    assert simulator_one.weather.equals(simulator_two.weather)
+
+
+def test_different_date_ranges_reuse_cached_normal_year(monkeypatch: pytest.MonkeyPatch) -> None:
+    attempts = {"count": 0}
+    normal_year_weather = _make_weather_frame()
+
+    def fake_download_normal_year_weather_sync(*args, **kwargs):
+        attempts["count"] += 1
+        return normal_year_weather
+
+    monkeypatch.setattr(
+        weather_module,
+        "_download_normal_year_weather_sync",
+        fake_download_normal_year_weather_sync,
+    )
+
+    first = weather_module._get_weather_sync(
+        latitude=51.2,
+        longitude=4.4,
+        start=dt.date(2024, 1, 1),
+        end=dt.date(2024, 1, 2),
+        tz="UTC",
+        timeout=30,
+        retry_count=2,
+        retry_backoff_seconds=1.0,
+    )
+    second = weather_module._get_weather_sync(
+        latitude=51.2,
+        longitude=4.4,
+        start=dt.date(2024, 1, 2),
+        end=dt.date(2024, 1, 3),
+        tz="UTC",
+        timeout=30,
+        retry_count=2,
+        retry_backoff_seconds=1.0,
+    )
+
+    assert attempts["count"] == 1
+    assert len(first) == 96
+    assert len(second) == 96
+    assert first.index[0] == pd.Timestamp("2024-01-01 00:00:00+0000", tz="UTC")
+    assert second.index[0] == pd.Timestamp("2024-01-02 00:00:00+0000", tz="UTC")
+
+
+def test_different_location_or_timezone_uses_separate_cache_entries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = {"count": 0}
+    normal_year_weather = _make_weather_frame()
+
+    def fake_download_normal_year_weather_sync(*args, **kwargs):
+        attempts["count"] += 1
+        return normal_year_weather
+
+    monkeypatch.setattr(
+        weather_module,
+        "_download_normal_year_weather_sync",
+        fake_download_normal_year_weather_sync,
+    )
+
+    weather_module._get_weather_sync(
+        latitude=51.2,
+        longitude=4.4,
+        start=dt.date(2024, 1, 1),
+        end=dt.date(2024, 1, 2),
+        tz="UTC",
+        timeout=30,
+        retry_count=2,
+        retry_backoff_seconds=1.0,
+    )
+    weather_module._get_weather_sync(
+        latitude=51.2,
+        longitude=4.4,
+        start=dt.date(2024, 1, 1),
+        end=dt.date(2024, 1, 2),
+        tz="Europe/Brussels",
+        timeout=30,
+        retry_count=2,
+        retry_backoff_seconds=1.0,
+    )
+    weather_module._get_weather_sync(
+        latitude=51.3,
+        longitude=4.4,
+        start=dt.date(2024, 1, 1),
+        end=dt.date(2024, 1, 2),
+        tz="UTC",
+        timeout=30,
+        retry_count=2,
+        retry_backoff_seconds=1.0,
+    )
+
+    assert attempts["count"] == 3
+
+
+def test_cached_hit_ignores_later_transport_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    attempts = {"count": 0}
+    normal_year_weather = _make_weather_frame()
+
+    def fake_download_normal_year_weather_sync(*args, **kwargs):
+        attempts["count"] += 1
+        return normal_year_weather
+
+    monkeypatch.setattr(
+        weather_module,
+        "_download_normal_year_weather_sync",
+        fake_download_normal_year_weather_sync,
+    )
+
+    weather_module._get_weather_sync(
+        latitude=51.2,
+        longitude=4.4,
+        start=dt.date(2024, 1, 1),
+        end=dt.date(2024, 1, 2),
+        tz="UTC",
+        timeout=10,
+        retry_count=0,
+        retry_backoff_seconds=0.1,
+    )
+    weather_module._get_weather_sync(
+        latitude=51.2,
+        longitude=4.4,
+        start=dt.date(2024, 2, 1),
+        end=dt.date(2024, 2, 2),
+        tz="UTC",
+        timeout=90,
+        retry_count=5,
+        retry_backoff_seconds=5.0,
+    )
+
+    assert attempts["count"] == 1
+
+
+def test_get_weather_retries_transient_failures_until_success_on_cold_miss(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     attempts = {"count": 0}
     sleep_calls: list[float] = []
-    expected = pd.DataFrame({"ghi": [1.0]}, index=pd.date_range("2024-01-01", periods=1, tz="UTC"))
+    normal_year_weather = _make_weather_frame()
 
-    def fake_get_weather_sync(*args, **kwargs):
+    def fake_download_normal_year_weather_sync(*args, **kwargs):
         attempts["count"] += 1
         if attempts["count"] < 3:
             raise requests.Timeout("temporary timeout")
-        return expected
+        return normal_year_weather
 
-    async def fake_to_thread(func, *args):
-        return func(*args)
+    monkeypatch.setattr(
+        weather_module,
+        "_download_normal_year_weather_sync",
+        fake_download_normal_year_weather_sync,
+    )
+    monkeypatch.setattr(weather_module.time, "sleep", sleep_calls.append)
 
-    async def fake_sleep(delay: float):
-        sleep_calls.append(delay)
+    result = weather_module._get_weather_sync(
+        latitude=51.2,
+        longitude=4.4,
+        start=dt.date(2024, 1, 1),
+        end=dt.date(2024, 1, 2),
+        tz="UTC",
+        timeout=7,
+        retry_count=2,
+        retry_backoff_seconds=0.5,
+    )
 
-    monkeypatch.setattr(weather_module, "_get_weather_sync", fake_get_weather_sync)
-    monkeypatch.setattr(weather_module.asyncio, "to_thread", fake_to_thread)
-    monkeypatch.setattr(weather_module.asyncio, "sleep", fake_sleep)
+    assert len(result) == 96
+    assert attempts["count"] == 3
+    assert sleep_calls == [0.5, 1.0]
 
-    result = asyncio.run(
-        weather_module.get_weather(
+
+def test_failed_download_is_not_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    attempts = {"count": 0}
+    normal_year_weather = _make_weather_frame()
+
+    def fake_download_normal_year_weather_sync(*args, **kwargs):
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise requests.ConnectionError("network down")
+        return normal_year_weather
+
+    monkeypatch.setattr(
+        weather_module,
+        "_download_normal_year_weather_sync",
+        fake_download_normal_year_weather_sync,
+    )
+
+    with pytest.raises(requests.ConnectionError, match="network down"):
+        weather_module._get_weather_sync(
             latitude=51.2,
             longitude=4.4,
             start=dt.date(2024, 1, 1),
             end=dt.date(2024, 1, 2),
             tz="UTC",
-            timeout=7,
-            retry_count=2,
-            retry_backoff_seconds=0.5,
+            timeout=30,
+            retry_count=0,
+            retry_backoff_seconds=1.0,
         )
+
+    result = weather_module._get_weather_sync(
+        latitude=51.2,
+        longitude=4.4,
+        start=dt.date(2024, 1, 1),
+        end=dt.date(2024, 1, 2),
+        tz="UTC",
+        timeout=30,
+        retry_count=0,
+        retry_backoff_seconds=1.0,
     )
 
-    assert result is expected
-    assert attempts["count"] == 3
-    assert sleep_calls == [0.5, 1.0]
-
-
-def test_get_weather_raises_after_retry_limit(monkeypatch: pytest.MonkeyPatch) -> None:
-    attempts = {"count": 0}
-    sleep_calls: list[float] = []
-
-    def fake_get_weather_sync(*args, **kwargs):
-        attempts["count"] += 1
-        raise requests.ConnectionError("network down")
-
-    async def fake_to_thread(func, *args):
-        return func(*args)
-
-    async def fake_sleep(delay: float):
-        sleep_calls.append(delay)
-
-    monkeypatch.setattr(weather_module, "_get_weather_sync", fake_get_weather_sync)
-    monkeypatch.setattr(weather_module.asyncio, "to_thread", fake_to_thread)
-    monkeypatch.setattr(weather_module.asyncio, "sleep", fake_sleep)
-
-    with pytest.raises(requests.ConnectionError, match="network down"):
-        asyncio.run(
-            weather_module.get_weather(
-                latitude=51.2,
-                longitude=4.4,
-                start=dt.date(2024, 1, 1),
-                end=dt.date(2024, 1, 2),
-                tz="UTC",
-                retry_count=2,
-                retry_backoff_seconds=0.25,
-            )
-        )
-
-    assert attempts["count"] == 3
-    assert sleep_calls == [0.25, 0.5]
+    assert attempts["count"] == 2
+    assert len(result) == 96
 
 
 def test_get_weather_does_not_retry_non_retryable_errors(
@@ -268,32 +454,123 @@ def test_get_weather_does_not_retry_non_retryable_errors(
     attempts = {"count": 0}
     sleep_calls: list[float] = []
 
-    def fake_get_weather_sync(*args, **kwargs):
+    def fake_download_normal_year_weather_sync(*args, **kwargs):
         attempts["count"] += 1
         raise requests.HTTPError("bad request")
 
-    async def fake_to_thread(func, *args):
-        return func(*args)
-
-    async def fake_sleep(delay: float):
-        sleep_calls.append(delay)
-
-    monkeypatch.setattr(weather_module, "_get_weather_sync", fake_get_weather_sync)
-    monkeypatch.setattr(weather_module.asyncio, "to_thread", fake_to_thread)
-    monkeypatch.setattr(weather_module.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(
+        weather_module,
+        "_download_normal_year_weather_sync",
+        fake_download_normal_year_weather_sync,
+    )
+    monkeypatch.setattr(weather_module.time, "sleep", sleep_calls.append)
 
     with pytest.raises(requests.HTTPError, match="bad request"):
-        asyncio.run(
-            weather_module.get_weather(
-                latitude=51.2,
-                longitude=4.4,
-                start=dt.date(2024, 1, 1),
-                end=dt.date(2024, 1, 2),
-                tz="UTC",
-                retry_count=2,
-                retry_backoff_seconds=0.25,
-            )
+        weather_module._get_weather_sync(
+            latitude=51.2,
+            longitude=4.4,
+            start=dt.date(2024, 1, 1),
+            end=dt.date(2024, 1, 2),
+            tz="UTC",
+            retry_count=2,
+            retry_backoff_seconds=0.25,
+            timeout=30,
         )
 
     assert attempts["count"] == 1
     assert sleep_calls == []
+
+
+def test_parallel_same_key_cold_misses_share_one_download(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = {"count": 0}
+    normal_year_weather = _make_weather_frame()
+    started = threading.Event()
+    release = threading.Event()
+    results: list[pd.DataFrame] = []
+
+    def fake_download_normal_year_weather_sync(*args, **kwargs):
+        attempts["count"] += 1
+        started.set()
+        if not release.wait(timeout=1):
+            raise TimeoutError("parallel test did not release in time")
+        return normal_year_weather
+
+    monkeypatch.setattr(
+        weather_module,
+        "_download_normal_year_weather_sync",
+        fake_download_normal_year_weather_sync,
+    )
+
+    def run_request() -> None:
+        result = weather_module._get_weather_sync(
+            latitude=51.2,
+            longitude=4.4,
+            start=dt.date(2024, 1, 1),
+            end=dt.date(2024, 1, 2),
+            tz="UTC",
+            timeout=30,
+            retry_count=2,
+            retry_backoff_seconds=1.0,
+        )
+        results.append(result)
+
+    thread_one = threading.Thread(target=run_request)
+    thread_two = threading.Thread(target=run_request)
+    thread_one.start()
+
+    try:
+        assert started.wait(timeout=1)
+
+        thread_two.start()
+        time.sleep(0.05)
+    finally:
+        release.set()
+        thread_one.join(timeout=1)
+        thread_two.join(timeout=1)
+
+    assert attempts["count"] == 1
+    assert not thread_one.is_alive()
+    assert not thread_two.is_alive()
+    assert len(results) == 2
+    assert results[0].equals(results[1])
+
+
+def test_clear_weather_cache_forces_refetch(monkeypatch: pytest.MonkeyPatch) -> None:
+    attempts = {"count": 0}
+    normal_year_weather = _make_weather_frame()
+
+    def fake_download_normal_year_weather_sync(*args, **kwargs):
+        attempts["count"] += 1
+        return normal_year_weather
+
+    monkeypatch.setattr(
+        weather_module,
+        "_download_normal_year_weather_sync",
+        fake_download_normal_year_weather_sync,
+    )
+
+    weather_module._get_weather_sync(
+        latitude=51.2,
+        longitude=4.4,
+        start=dt.date(2024, 1, 1),
+        end=dt.date(2024, 1, 2),
+        tz="UTC",
+        timeout=30,
+        retry_count=2,
+        retry_backoff_seconds=1.0,
+    )
+    weather_module.clear_weather_cache()
+    weather_module._get_weather_sync(
+        latitude=51.2,
+        longitude=4.4,
+        start=dt.date(2024, 1, 1),
+        end=dt.date(2024, 1, 2),
+        tz="UTC",
+        timeout=30,
+        retry_count=2,
+        retry_backoff_seconds=1.0,
+    )
+
+    assert attempts["count"] == 2

--- a/uv.lock
+++ b/uv.lock
@@ -1612,6 +1612,7 @@ dependencies = [
     { name = "pandera", extra = ["polars"] },
     { name = "pvlib" },
     { name = "pydantic" },
+    { name = "requests" },
     { name = "scikit-learn" },
     { name = "statsmodels" },
 ]
@@ -1646,6 +1647,7 @@ requires-dist = [
     { name = "pandera", extras = ["polars"], specifier = ">=0.22.1" },
     { name = "pvlib", specifier = ">=0.13.0" },
     { name = "pydantic", specifier = ">=2.8.2" },
+    { name = "requests", specifier = ">=2.32.3" },
     { name = "scikit-learn", specifier = ">=1.8.0" },
     { name = "statsmodels", specifier = ">=0.14.2" },
 ]


### PR DESCRIPTION
In order to reduce errors where PVGIS weather data cannot be loaded or times out:

- Weather data gets cached
- Fetching is moved to a separate thread (to avoid blocking)
- Timeouts and retries are added and are configurable.